### PR TITLE
chore: harden docs toolchain installs

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -41,4 +41,4 @@ tasks:
   install:
     desc: "Install dependencies"
     cmds:
-      - pnpm install
+      - pnpm install --frozen-lockfile

--- a/bin/hermit.hcl
+++ b/bin/hermit.hcl
@@ -1,2 +1,4 @@
+sources = ["https://github.com/usetero/hermit-packages.git", "https://github.com/cashapp/hermit-packages.git"]
+
 github-token-auth {
 }


### PR DESCRIPTION
## Summary\n- configure Hermit to use the usetero package overlay first with the upstream catalog as fallback\n- switch docs dependency installs to pnpm install --frozen-lockfile\n\n## Validation\n- ./bin/hermit status\n- task --list