### PR TITLE
feat: add demo links to screenshots

### DIFF
--- a/integrations/datadog.mdx
+++ b/integrations/datadog.mdx
@@ -60,6 +60,7 @@ purpose: Connects the Datadog integration to current Tero screens.
 <Frame>
   <img src="/images/screenshots/integrations/datadog-log-ingestion.png" alt="Datadog log ingestion analysis shows where you can move waste upstream with policies." />
 </Frame>
+<p className="screenshot-caption"><small>Datadog log ingestion analysis shows where you can move waste upstream with policies. <a className="demo-screenshot-link" href="https://demo.usetero.com/ingestion" target="_blank" rel="noopener noreferrer">Open in demo <Icon icon="arrow-up-right-from-square" /></a></small></p>
 {/* /screenshot-generated */}
 
 ## Provider actions

--- a/introduction/how-tero-works.mdx
+++ b/introduction/how-tero-works.mdx
@@ -29,6 +29,7 @@ purpose: Shows that Tero starts from reviewable findings, not from a blank polic
 <Frame>
   <img src="/images/screenshots/introduction/issues-filtered-by-cost.png" alt="Issues show the work queue for telemetry control." />
 </Frame>
+<p className="screenshot-caption"><small>Issues show the work queue for telemetry control. <a className="demo-screenshot-link" href="https://demo.usetero.com/issues" target="_blank" rel="noopener noreferrer">Open in demo <Icon icon="arrow-up-right-from-square" /></a></small></p>
 {/* /screenshot-generated */}
 
 Cost and Compliance lanes give you another view of the same work. They group affected services and link back to the issues that explain the problem.
@@ -55,6 +56,7 @@ purpose: Shows the policy recommendation without the surrounding issue list or f
 <Frame>
   <img src="/images/screenshots/introduction/issue-detail-evidence-policy.png" alt="The recommended policy card connects evidence to a concrete action." />
 </Frame>
+<p className="screenshot-caption"><small>The recommended policy card connects evidence to a concrete action. <a className="demo-screenshot-link" href="https://demo.usetero.com/issues" target="_blank" rel="noopener noreferrer">Open in demo <Icon icon="arrow-up-right-from-square" /></a></small></p>
 {/* /screenshot-generated */}
 
 ## 3. A policy captures the change
@@ -78,6 +80,7 @@ purpose: Shows how Tero represents an approved recommendation as a reviewable po
 <Frame>
   <img src="/images/screenshots/introduction/policy-captures-change.png" alt="Policy detail shows the reviewed change, its source issue, spec, activity, and deployment state." />
 </Frame>
+<p className="screenshot-caption"><small>Policy detail shows the reviewed change, its source issue, spec, activity, and deployment state. <a className="demo-screenshot-link" href="https://demo.usetero.com/policies/kafka-log-segment-deletion" target="_blank" rel="noopener noreferrer">Open in demo <Icon icon="arrow-up-right-from-square" /></a></small></p>
 {/* /screenshot-generated */}
 
 ## 4. Runtime surfaces show where policies run
@@ -99,6 +102,7 @@ purpose: Shows how Tero connects approved policies to execution surfaces.
 <Frame>
   <img src="/images/screenshots/introduction/edge-runtime-policy-state.png" alt="Edge instances show runtime policy state." />
 </Frame>
+<p className="screenshot-caption"><small>Edge instances show runtime policy state. <a className="demo-screenshot-link" href="https://demo.usetero.com/edge" target="_blank" rel="noopener noreferrer">Open in demo <Icon icon="arrow-up-right-from-square" /></a></small></p>
 {/* /screenshot-generated */}
 
 Tero shows state and review controls. Providers, Git repositories, collectors, and Edge instances perform the production changes.
@@ -122,4 +126,5 @@ purpose: Shows the impact surface Tero uses to connect issue review to measured 
 <Frame>
   <img src="/images/screenshots/introduction/cost-impact-overview.png" alt="Cost shows whether telemetry policy work changed spend and recoverable savings." />
 </Frame>
+<p className="screenshot-caption"><small>Cost shows whether telemetry policy work changed spend and recoverable savings. <a className="demo-screenshot-link" href="https://demo.usetero.com/cost" target="_blank" rel="noopener noreferrer">Open in demo <Icon icon="arrow-up-right-from-square" /></a></small></p>
 {/* /screenshot-generated */}

--- a/introduction/what-is-tero.mdx
+++ b/introduction/what-is-tero.mdx
@@ -24,6 +24,7 @@ purpose: Shows how Tero moves from a detected issue to reviewable action.
 <Frame>
   <img src="/images/screenshots/introduction/issues-work-queue.png" alt="Issues are the main entry point for telemetry policy control." />
 </Frame>
+<p className="screenshot-caption"><small>Issues are the main entry point for telemetry policy control. <a className="demo-screenshot-link" href="https://demo.usetero.com/issues" target="_blank" rel="noopener noreferrer">Open in demo <Icon icon="arrow-up-right-from-square" /></a></small></p>
 {/* /screenshot-generated */}
 
 Tero helps you control telemetry policy. It finds issues across cost, compliance, and signal quality. Each issue includes evidence, provenance, impact, and a recommended policy or action. You review the evidence before you decide what should change.

--- a/issues/overview.mdx
+++ b/issues/overview.mdx
@@ -25,6 +25,7 @@ purpose: Shows the main review surface for telemetry control.
 <Frame>
   <img src="/images/screenshots/issues/issues-overview-workspace.png" alt="The Issues workspace combines filters, a work queue, and issue detail." />
 </Frame>
+<p className="screenshot-caption"><small>The Issues workspace combines filters, a work queue, and issue detail. <a className="demo-screenshot-link" href="https://demo.usetero.com/issues?status=open" target="_blank" rel="noopener noreferrer">Open in demo <Icon icon="arrow-up-right-from-square" /></a></small></p>
 {/* /screenshot-generated */}
 
 ## How issues fit into review

--- a/issues/review-an-issue.mdx
+++ b/issues/review-an-issue.mdx
@@ -46,6 +46,7 @@ purpose: Supports the core review step before action.
 <Frame>
   <img src="/images/screenshots/issues/review-issue-evidence.png" alt="The evidence panel shows the facts behind a recommended policy." />
 </Frame>
+<p className="screenshot-caption"><small>The evidence panel shows the facts behind a recommended policy. <a className="demo-screenshot-link" href="https://demo.usetero.com/issues" target="_blank" rel="noopener noreferrer">Open in demo <Icon icon="arrow-up-right-from-square" /></a></small></p>
 {/* /screenshot-generated */}
 
 ## Inspect the policy card

--- a/master-catalog/log-events.mdx
+++ b/master-catalog/log-events.mdx
@@ -22,6 +22,7 @@ purpose: Shows the catalog object behind many issue evidence panels.
 <Frame>
   <img src="/images/screenshots/master-catalog/log-events-catalog.png" alt="Log events group raw logs into patterns you can review." />
 </Frame>
+<p className="screenshot-caption"><small>Log events group raw logs into patterns you can review. <a className="demo-screenshot-link" href="https://demo.usetero.com/log-events" target="_blank" rel="noopener noreferrer">Open in demo <Icon icon="arrow-up-right-from-square" /></a></small></p>
 {/* /screenshot-generated */}
 
 ## Log event list

--- a/master-catalog/services.mdx
+++ b/master-catalog/services.mdx
@@ -22,6 +22,7 @@ purpose: Shows the service catalog surface behind issue review.
 <Frame>
   <img src="/images/screenshots/master-catalog/services-catalog.png" alt="The Services list shows the owner, open issues, log volume, and cost for each service." />
 </Frame>
+<p className="screenshot-caption"><small>The Services list shows the owner, open issues, log volume, and cost for each service. <a className="demo-screenshot-link" href="https://demo.usetero.com/services" target="_blank" rel="noopener noreferrer">Open in demo <Icon icon="arrow-up-right-from-square" /></a></small></p>
 {/* /screenshot-generated */}
 
 ## Service list

--- a/policies/overview.mdx
+++ b/policies/overview.mdx
@@ -33,6 +33,7 @@ purpose: Shows policies as reviewable control-plane artifacts rather than hidden
 <Frame>
   <img src="/images/screenshots/policies/policies-table.png" alt="Policies show status, action, source, service, activity, and linked issue." />
 </Frame>
+<p className="screenshot-caption"><small>Policies show status, action, source, service, activity, and linked issue. <a className="demo-screenshot-link" href="https://demo.usetero.com/policies" target="_blank" rel="noopener noreferrer">Open in demo <Icon icon="arrow-up-right-from-square" /></a></small></p>
 {/* /screenshot-generated */}
 
 ## How policies relate to issues
@@ -78,6 +79,7 @@ purpose: Shows how reviewers inspect policy state after approval.
 <Frame>
   <img src="/images/screenshots/policies/policy-detail-overview.png" alt="Policy detail connects spec, activity, linked issue, and deployments." />
 </Frame>
+<p className="screenshot-caption"><small>Policy detail connects spec, activity, linked issue, and deployments. <a className="demo-screenshot-link" href="https://demo.usetero.com/policies/kafka-log-segment-deletion" target="_blank" rel="noopener noreferrer">Open in demo <Icon icon="arrow-up-right-from-square" /></a></small></p>
 {/* /screenshot-generated */}
 
 The issue link returns you to the evidence. Open Deployments for runtime state, or Spec for the exact match and action.

--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -36,6 +36,7 @@ purpose: Gives the learner a visual target for the first step.
 <Frame>
   <img src="/images/screenshots/quickstart/quickstart-issues-list.png" alt="The Issues workspace shows open telemetry findings ready for review." />
 </Frame>
+<p className="screenshot-caption"><small>The Issues workspace shows open telemetry findings ready for review. <a className="demo-screenshot-link" href="https://demo.usetero.com/issues?status=open" target="_blank" rel="noopener noreferrer">Open in demo <Icon icon="arrow-up-right-from-square" /></a></small></p>
 {/* /screenshot-generated */}
 
 You should see a work queue with open issues. Each row shows the issue status, severity, title, affected service or team, check type, and domain such as Cost or Compliance.
@@ -76,6 +77,7 @@ purpose: Teaches the learner to review evidence before trusting the recommendati
 <Frame>
   <img src="/images/screenshots/quickstart/quickstart-issue-evidence.png" alt="Issue evidence shows why Tero recommended action." />
 </Frame>
+<p className="screenshot-caption"><small>Issue evidence shows why Tero recommended action. <a className="demo-screenshot-link" href="https://demo.usetero.com/issues" target="_blank" rel="noopener noreferrer">Open in demo <Icon icon="arrow-up-right-from-square" /></a></small></p>
 {/* /screenshot-generated */}
 
 Stop here and check whether the finding makes sense. Use this pass to learn how Tero connects a finding to evidence you can inspect.
@@ -107,6 +109,7 @@ purpose: Shows where the learner goes after reviewing an issue recommendation.
 <Frame>
   <img src="/images/screenshots/quickstart/quickstart-policy-detail.png" alt="Policies show status, source, action, service, activity, and linked issue." />
 </Frame>
+<p className="screenshot-caption"><small>Policies show status, source, action, service, activity, and linked issue. <a className="demo-screenshot-link" href="https://demo.usetero.com/policies" target="_blank" rel="noopener noreferrer">Open in demo <Icon icon="arrow-up-right-from-square" /></a></small></p>
 {/* /screenshot-generated */}
 
 You should see policy status, action, source, service, recent hits, update time, and linked issue. Open a policy detail page to review the overview, deployments, and spec tabs.

--- a/scripts/screenshot-suggestions.mjs
+++ b/scripts/screenshot-suggestions.mjs
@@ -6,6 +6,8 @@ import path from "node:path";
 const ROOT = process.cwd();
 const DEFAULT_BASE_URL =
   process.env.TERO_SCREENSHOT_BASE_URL || "https://demo.usetero.com";
+const DEMO_BASE_URL =
+  process.env.TERO_SCREENSHOT_DEMO_BASE_URL || "https://demo.usetero.com";
 
 const DESKTOP_VIEWPORT = { width: 1440, height: 1000 };
 const MOBILE_VIEWPORT = { width: 390, height: 844 };
@@ -173,6 +175,7 @@ function parseSuggestions(text, file) {
       file,
       blockEnd: match.index + match[0].length,
       blockStart: match.index,
+      demoUrl: new URL(fields.appRoute, normalizedBaseUrl(DEMO_BASE_URL)).toString(),
       url: new URL(fields.appRoute, normalizedBaseUrl(args.baseUrl)).toString(),
       outputPath: path.resolve(ROOT, fields.output.replace(/^\//, "")),
     });
@@ -352,12 +355,24 @@ function renderEmbed(suggestion) {
       suggestion.caption,
     )}" />`,
     "</Frame>",
+    `<p className="screenshot-caption"><small>${escapeHtml(
+      suggestion.caption,
+    )} <a className="demo-screenshot-link" href="${escapeAttribute(
+      suggestion.demoUrl,
+    )}" target="_blank" rel="noopener noreferrer">Open in demo <Icon icon="arrow-up-right-from-square" /></a></small></p>`,
     "{/* /screenshot-generated */}",
   ].join("\n");
 }
 
 function escapeAttribute(value) {
   return value.replaceAll("&", "&amp;").replaceAll('"', "&quot;");
+}
+
+function escapeHtml(value) {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
 }
 
 function escapeRegExp(value) {

--- a/style.css
+++ b/style.css
@@ -86,6 +86,35 @@ body {
   text-underline-offset: 3px;
 }
 
+.screenshot-caption {
+  margin-top: 0.55rem;
+  color: var(--tero-muted);
+}
+
+.screenshot-caption small {
+  color: inherit;
+  font-size: 0.88rem;
+  line-height: 1.45;
+}
+
+.demo-screenshot-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.22em;
+  color: var(--tero-accent-ink);
+  font-weight: 500;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 0.18em;
+  white-space: nowrap;
+}
+
+.demo-screenshot-link svg {
+  width: 0.82em !important;
+  height: 0.82em !important;
+  background-color: currentColor !important;
+  transform: translateY(-0.04em);
+}
+
 #sidebar {
   border-right-color: var(--tero-line);
   background: var(--tero-bg);


### PR DESCRIPTION
## Summary

- Add captions and external demo links to generated screenshot embeds across Tero docs pages.
- Update the screenshot suggestion embed script so regenerated screenshots include the same caption/link markup.
- Add caption and inline demo-link styling, including the external-link icon.

## Validation

- `git diff --check`
- `task do`