### PR TITLE
docs: agent-experience cleanup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,12 +2,14 @@
 
 This is Tero's public documentation repository, built with [Mintlify](https://mintlify.com). It contains customer-facing documentation for understanding, integrating, and using Tero.
 
+`CLAUDE.md` is a symlink to this file — edit `AGENTS.md`.
+
 ## What This Repo Is
 
 A Mintlify-based documentation site with:
 - **MDX files** - Documentation pages (content)
 - **docs.json** - Navigation and site configuration
-- **docs/** - Internal planning docs (organization, writing guide, outlines)
+- **meta/** - Internal planning docs (philosophy, voice, product model)
 - **Taskfile.yml** - Development commands
 - **Hermit** - Tool management (node, pnpm, task)
 
@@ -17,34 +19,40 @@ This is a public repository. Customers may contribute. Write accordingly.
 
 ```
 docs/
-├── docs/               # Internal planning (not published)
-│   ├── organization.md # How docs are structured and why
-│   ├── manual.md       # Complete Manual outline
-│   └── writing.md      # Writing guidelines
-├── manual/             # Manual section (progressive journey)
-├── integrations/       # Vendor-specific guides
-├── reference/          # Component documentation
-├── trust/              # Trust Center content
+├── meta/               # Internal planning (not published)
+│   ├── philosophy.md   # Why the docs exist, who reads them
+│   ├── voice.md        # Writing voice and tone
+│   ├── model.md        # Product mental model the docs teach
+│   ├── trust-center.md # Operating spec for Trust content
+│   └── todo.md         # Documentation TODOs
+├── introduction/       # What Tero is, how it works (Tero tab)
+├── issues/             # Issues workspace docs (Tero tab)
+├── master-catalog/     # Master Catalog docs (Tero tab)
+├── policies/           # Policy docs: categories, enforcement (Tero tab)
+├── integrations/       # Vendor-specific guides (split across tabs)
+├── edge/               # Edge runtime docs (Edge tab)
+├── trust/              # Trust Center content (Trust tab)
 ├── snippets/           # Reusable content blocks
+├── scripts/            # Screenshot tooling
 ├── docs.json           # Navigation configuration
-└── *.mdx               # Documentation pages
+└── quickstart.mdx      # Product quickstart
 ```
 
 ## Documentation Organization
 
-We follow a three-section structure:
+Navigation has three tabs, each serving a distinct audience and job:
 
-**Manual** - Progressive journey from first contact to organizational rollout. Designed to be read sequentially. Each section builds on the last.
+**Tero** - The product. What it is, how it works, the quickstart, and the core workspaces: Issues, Master Catalog, Policies. Organized by product area; each area holds its own explanation, how-to, and reference pages.
 
-**Integrations** - Vendor-specific guides (Datadog, Splunk, etc.). Self-contained, tell the complete integration story.
+**Edge** - The data plane. For engineers deploying and operating Edge: concepts, quickstart, distributions, deployment how-tos, configuration and policy reference.
 
-**Reference** - Component documentation (CLI, Edge, API). Non-progressive, random-access lookup.
+**Trust** - Security review. Architecture, controls, assurance, and security policies for reviewers evaluating Tero.
 
-See `docs/organization.md` for the complete thinking behind this structure.
+Tabs are audience boundaries, not document-type boundaries. Don't create catch-all "Reference" or "Guides" groups that pull pages out of their product area — keep each area self-contained so the sidebar and URL hierarchy agree.
 
 ## Writing Documentation
 
-We follow the [Diataxis framework](https://diataxis.fr/) for documentation types and [Google's Developer Documentation Style Guide](https://developers.google.com/style) for technical writing.
+We follow the [Diataxis framework](https://diataxis.fr/) for documentation types and [Google's Developer Documentation Style Guide](https://developers.google.com/style) for technical writing. Diataxis governs the form of each page, not the navigation — don't reorganize the sidebar around it.
 
 Tero's style:
 - Conversational but not casual
@@ -52,34 +60,40 @@ Tero's style:
 - Action-oriented, respect reader's intelligence
 - Progressive disclosure (simple → complex)
 
-See `docs/writing.md` for complete guidelines and type-specific guidance (Tutorial vs How-to vs Reference vs Explanation).
+See `meta/voice.md` for voice and tone, `meta/philosophy.md` for who the reader is and what earns their trust, and `meta/model.md` for the product mental model the docs should build.
 
 ## Key Principles
 
 **Only publish what exists** - Don't create pages marked "Coming Soon." Add sections as features ship. This shows momentum instead of a TODO list.
 
-**Progressive trust** - The Manual follows how customers actually adopt: understand → analyze (read-only) → configure → deploy edge → scale org-wide. Each step builds trust.
+**Progressive trust** - Docs follow how customers actually adopt: understand → analyze (read-only) → configure → deploy edge → scale org-wide. Each step builds trust.
 
 **Self-contained integrations** - Each vendor integration page tells the complete story. Don't scatter setup across multiple sections.
 
 **Reference is for lookup** - Not progressive. Jump to what you need. Self-contained pages.
+
+**Titles must work out of context** - Agents consume pages through `llms.txt` and the MCP server as flat title + description lists, without tab context. Make titles globally unambiguous ("Edge quickstart", not a second "Quickstart") and never reuse a title across pages.
 
 ## Common Tasks
 
 ### Writing a New Doc Page
 
 1. Determine the type (Tutorial, How-to, Reference, Explanation) - see Diataxis
-2. Check `docs/manual.md` or relevant outline for where it fits
-3. Write following `docs/writing.md` guidelines
-4. Add to `docs.json` navigation
+2. Place it in the product area it belongs to (directory and nav group should agree)
+3. Write following `meta/voice.md` and `meta/philosophy.md`
+4. Add to `docs.json` navigation - a page not in navigation is still served by URL, so never leave orphans
 5. Use snippets for reusable content (permissions, verification steps)
 
 ### Updating Docs
 
-1. Read `docs/writing.md` for editing principles
+1. Read `meta/voice.md` for editing principles
 2. Rewrite sections to stay coherent - don't just append
 3. Maintain voice throughout
 4. Update `docs.json` if structure changes
+
+### Screenshots
+
+Pages embed app screenshots via `screenshot-suggestion` comment blocks in MDX. Run `task screenshots` to capture and embed them, or `task screenshots:dry` to list suggestions without writing files. Generated blocks are marked `screenshot-generated` - edit the suggestion, not the generated markup.
 
 ### Checking Quality
 
@@ -99,10 +113,12 @@ pnpm install
 
 **Common commands:**
 ```bash
-task dev          # Start Mintlify dev server
-task do           # Fast dev loop (format + lint)
-task check:links  # Check for broken links
-task build        # Build documentation
+task dev              # Start Mintlify dev server
+task do               # Fast dev loop (format + lint)
+task check:links      # Check for broken links
+task build            # Build documentation
+task screenshots      # Capture and embed screenshots
+task screenshots:dry  # List screenshot suggestions
 ```
 
 **Preview:** Dev server runs at `http://localhost:3000`
@@ -114,26 +130,30 @@ Navigation follows this structure:
 {
   "navigation": {
     "tabs": [
-      { "tab": "Manual", "groups": [...] },
-      { "tab": "Integrations", "groups": [...] },
-      { "tab": "Reference", "groups": [...] }
-    ],
-    "global": {
-      "anchors": [
-        { "anchor": "Trust Center", ... }
-      ]
-    }
+      { "tab": "Tero", "groups": [...] },
+      { "tab": "Edge", "groups": [...] },
+      { "tab": "Trust", "groups": [...] }
+    ]
   }
 }
 ```
 
-Tabs appear in top navigation. Global anchors are persistent sidebar items (Trust Center, Support, Status).
+Tabs appear in top navigation. The `contextual` block configures the page-level AI menu (copy as Markdown, open in ChatGPT/Claude/Cursor, MCP server).
+
+## Agents and AI Consumption
+
+Mintlify auto-hosts agent infrastructure for this site - no configuration lives in this repo:
+
+- `llms.txt` at the site root indexes all pages (title + description, ordered by navigation)
+- An MCP server at `/mcp` lets AI tools query live docs
+- `skill.md` backs `npx skills add https://docs.usetero.com` (the quickstarts point readers at this)
+- Appending `.md` to any page URL returns clean Markdown
+
+Practical consequences: navigation structure and frontmatter descriptions are agent-facing surfaces, not just chrome. Keep descriptions specific and titles unambiguous.
 
 ## For Tero Employees
 
-Reference these internal docs for deeper context:
-- `../knowledge-base/meta/writing.md` - Company writing style
-- `../.github-private/manual/documentation.md` - Repository documentation practices
+Reference `../knowledge-base/meta/writing.md` for company writing style.
 
 ## Mintlify-Specific
 

--- a/edge/distributions/all.mdx
+++ b/edge/distributions/all.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Edge"
+title: "Edge Full"
 description: "Full Edge distribution supporting all protocols"
 icon: "cubes"
 iconType: "duotone"

--- a/edge/github-edge.mdx
+++ b/edge/github-edge.mdx
@@ -1,5 +1,6 @@
 ---
-title: "Edge"
+title: "Edge Source"
+sidebarTitle: "Edge"
 icon: "github"
 iconType: "brands"
 url: "https://github.com/usetero/edge"

--- a/edge/quickstart.mdx
+++ b/edge/quickstart.mdx
@@ -1,11 +1,15 @@
 ---
-title: "Quickstart"
+title: "Edge Quickstart"
 description: "Run Edge locally and verify one policy"
 icon: "rocket"
 iconType: "duotone"
 ---
 
 Run Edge locally with a file-backed policy, send two test logs, and verify Edge drops the debug log and forwards the error log.
+
+<Tip>
+Prefer an AI assistant to walk you through this? Run `npx skills add https://docs.usetero.com` to add these docs as a skill in Claude Code, Codex, or Cursor. Then ask questions like "how do I run Edge locally?" and your agent guides you using Tero's documentation.
+</Tip>
 
 ## Before you begin
 

--- a/policies/management.mdx
+++ b/policies/management.mdx
@@ -1,8 +1,0 @@
----
-title: "Policy lifecycle"
-description: "Policy state, deployment, and impact reference"
-icon: "folder-tree"
-iconType: "duotone"
----
-
-Policy lifecycle reference moved to [Policy lifecycle](/policies/lifecycle).

--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -1,11 +1,15 @@
 ---
-title: "Quickstart"
+title: "Tero Quickstart"
 description: "See what your telemetry costs, then review your first issue"
 icon: "rocket"
 iconType: "duotone"
 ---
 
 You will see what your telemetry estate costs, find where compliance exposure lives, then review one open issue, inspect its evidence, and find the policy Tero recommends.
+
+<Tip>
+Prefer an AI assistant to walk you through this? Run `npx skills add https://docs.usetero.com` to add these docs as a skill in Claude Code, Codex, or Cursor. Then ask questions like "how do I connect Datadog to Tero?" and your agent guides you using Tero's documentation.
+</Tip>
 
 ## Before you begin
 

--- a/trust/policies/index.mdx
+++ b/trust/policies/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Policies"
+title: "Security Policies"
 sidebarTitle: "Policies"
 description: "Policy library for trust controls and handling standards."
 icon: "folder-tree"


### PR DESCRIPTION
## Summary

Makes the docs work better for AI agents (llms.txt, MCP, skills) without compromising the human experience.

- **Quickstart tips**: Both the Tero and Edge quickstarts now point readers at `npx skills add https://docs.usetero.com` so Claude Code, Codex, or Cursor can guide them through Tero.
- **AGENTS.md rewrite**: The old file described an IA that no longer exists (Manual/Integrations/Reference tabs, a deleted `docs/` planning folder). It now documents the real Tero/Edge/Trust structure and its rationale, the `meta/` planning docs, the screenshot workflow, and the Mintlify agent surfaces (llms.txt, `/mcp`, skill.md, `.md` content negotiation) — plus guardrails so future agents keep titles unambiguous and nav aligned with URLs. `CLAUDE.md` symlinks here, so both are fixed.
- **Title collision fixes**: Agents consume pages as flat title + description lists, where duplicate titles are indistinguishable. Retitled: "Tero Quickstart" / "Edge Quickstart", "Security Policies" (trust index, sidebar label unchanged), "Edge Source" (GitHub link, sidebar label unchanged), "Edge Full" (matches "Edge Datadog" / "Edge OTLP" siblings). No two pages share a title now.
- **Orphan removal**: Deleted `policies/management.mdx` — unreachable from navigation, unlinked from any page, and it duplicated the "Policy lifecycle" title.

No URLs change, so no redirects needed.

## Test plan

- `task check:links` passes
- Verified no duplicate `title:` frontmatter remains across published pages
- After deploy: spot-check https://docs.usetero.com/llms.txt for the new titles